### PR TITLE
Add CI workflow for lint, typecheck and build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,29 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - run: bun install --frozen-lockfile
+
+      - name: Lint & format
+        run: bun run lint
+
+      - name: Type check
+        run: bunx tsc --noEmit
+
+      - name: Build
+        run: bun run build


### PR DESCRIPTION
## Summary
- Adds a GitHub Actions CI workflow that runs on pushes to `main` and PRs targeting `main`
- Runs lint & format (Biome), type checking (tsc), and build (Vite) using Bun

## Test plan
- [ ] Verify the workflow triggers on this PR
- [ ] Confirm all three steps (lint, typecheck, build) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)