### PR TITLE
Move toasts to ToastProvider

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,15 +1,15 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import ContributionCard from "./components/ContributionCard";
 import SettingsDrawer from "./components/SettingsDrawer";
-import ToastContainer from "./components/Toast";
+
 import Toolbar from "./components/Toolbar";
 import UserDetailModal from "./components/UserDetailModal";
 import { computeBadges } from "./lib/badges";
 import { getDatePresets } from "./lib/datePresets";
 import { gql, QUERY_ORG, QUERY_USER } from "./lib/github";
 import { DEFAULT_VISIBLE_STATS } from "./lib/stats";
+import { useToast } from "./lib/ToastContext";
 import type { GitHubUser, UserResult } from "./lib/types";
-import { useToasts } from "./lib/useToasts";
 
 interface UrlState {
   users?: string[];
@@ -69,7 +69,7 @@ export default function App() {
   const [selectedUser, setSelectedUser] = useState<{ username: string; rect: DOMRect } | null>(
     null,
   );
-  const { toasts, addToast, dismissToast } = useToasts();
+  const { addToast } = useToast();
 
   const allLoaded = users.length > 0 && users.every((u) => results[u]?.data || results[u]?.error);
   const sortedUsers = useMemo(() => {
@@ -322,8 +322,6 @@ export default function App() {
           onClose={() => setSelectedUser(null)}
         />
       )}
-
-      <ToastContainer toasts={toasts} onDismiss={dismissToast} />
 
       <footer className="mt-auto pt-12 py-6 text-center text-xs text-gh-text-secondary border-t border-gh-border">
         <a

--- a/src/lib/ToastContext.tsx
+++ b/src/lib/ToastContext.tsx
@@ -1,0 +1,27 @@
+import { createContext, type ReactNode, useContext } from "react";
+import type { ToastType } from "../components/Toast";
+import ToastContainer from "../components/Toast";
+import { useToasts } from "./useToasts";
+
+interface ToastContextValue {
+  addToast: (type: ToastType, text: string) => void;
+}
+
+const ToastContext = createContext<ToastContextValue | null>(null);
+
+export function ToastProvider({ children }: { children: ReactNode }) {
+  const { toasts, addToast, dismissToast } = useToasts();
+
+  return (
+    <ToastContext.Provider value={{ addToast }}>
+      {children}
+      <ToastContainer toasts={toasts} onDismiss={dismissToast} />
+    </ToastContext.Provider>
+  );
+}
+
+export function useToast() {
+  const ctx = useContext(ToastContext);
+  if (!ctx) throw new Error("useToast must be used within a ToastProvider");
+  return ctx;
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,11 +1,14 @@
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import App from "./App";
+import { ToastProvider } from "./lib/ToastContext";
 import "./index.css";
 
 // biome-ignore lint/style/noNonNullAssertion: root element always exists in index.html
 createRoot(document.getElementById("root")!).render(
   <StrictMode>
-    <App />
+    <ToastProvider>
+      <App />
+    </ToastProvider>
   </StrictMode>,
 );


### PR DESCRIPTION
This moves the toasts to a global context to be able to use toasts across the whole app