### PR TITLE
Improve accessibility

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -293,7 +293,13 @@ export default function App() {
   const gridCols = Math.min(users.length || 1, 3);
 
   return (
-    <div className="min-h-screen bg-gh-bg text-gh-text-primary p-4 sm:p-6 font-sans flex flex-col">
+    <main className="min-h-screen bg-gh-bg text-gh-text-primary p-4 sm:p-6 font-sans flex flex-col">
+      <a
+        href="#dashboard"
+        className="sr-only focus:not-sr-only focus:absolute focus:z-50 focus:p-3 focus:bg-gh-accent focus:text-white focus:rounded-lg focus:top-2 focus:left-2"
+      >
+        Skip to content
+      </a>
       <Toolbar
         fromDate={fromDate}
         setFromDate={setFromDate}
@@ -328,7 +334,10 @@ export default function App() {
         )}
 
         {users.length === 0 ? (
-          <div className="flex flex-col items-center justify-center py-24 text-gh-text-secondary">
+          <div
+            role="status"
+            className="flex flex-col items-center justify-center py-24 text-gh-text-secondary"
+          >
             <p className="text-base mb-2">No users configured</p>
             <button
               type="button"
@@ -392,15 +401,21 @@ export default function App() {
           href="https://github.com/brdv/ghcd"
           target="_blank"
           rel="noreferrer"
+          aria-label="GHCD project on GitHub"
           className="text-gh-accent hover:text-gh-accent-hover"
         >
           GHCD
         </a>{" "}
-        — Created with ❤️ by{" "}
+        — Created with{" "}
+        <span role="img" aria-label="love">
+          ❤️
+        </span>{" "}
+        by{" "}
         <a
           href="https://github.com/brdv"
           target="_blank"
           rel="noreferrer"
+          aria-label="brdv on GitHub"
           className="text-gh-accent hover:text-gh-accent-hover"
         >
           brdv
@@ -410,11 +425,12 @@ export default function App() {
           href="https://github.com/mathijsr94"
           target="_blank"
           rel="noreferrer"
+          aria-label="mathijsr94 on GitHub"
           className="text-gh-accent hover:text-gh-accent-hover"
         >
           mathijsr94
         </a>
       </footer>
-    </div>
+    </main>
   );
 }

--- a/src/components/ContributionCard.tsx
+++ b/src/components/ContributionCard.tsx
@@ -25,7 +25,7 @@ export default function ContributionCard({
   visibleStats,
   onSelect,
 }: ContributionCardProps) {
-  const cardRef = useRef<HTMLDivElement>(null);
+  const cardRef = useRef<HTMLElement>(null);
   const [avatarLoaded, setAvatarLoaded] = useState(false);
   const collection = result.data?.contributionsCollection;
   const totalContributions = collection?.contributionCalendar.totalContributions;
@@ -40,23 +40,19 @@ export default function ContributionCard({
     }
   }
 
+  const sharedClass = `bg-gh-card rounded-xl px-5 py-4 transition-colors duration-150 w-full text-left ${
+    hasStreak ? "streak-glow border border-transparent" : "border border-gh-border"
+  }`;
+
+  const Wrapper = isClickable ? "button" : "div";
+
   return (
-    // biome-ignore lint/a11y/noStaticElementInteractions: role is conditionally set to "button" when clickable
-    <div
-      ref={cardRef}
-      className={`bg-gh-card rounded-xl px-5 py-4 transition-colors duration-150 ${
-        hasStreak ? "streak-glow border border-transparent" : "border border-gh-border"
-      } ${isClickable ? "cursor-pointer hover:border-gh-accent/50" : ""}`}
+    <Wrapper
+      ref={cardRef as React.Ref<HTMLButtonElement & HTMLDivElement>}
+      type={isClickable ? "button" : undefined}
+      aria-label={isClickable ? `View details for ${username}` : undefined}
+      className={`${sharedClass} ${isClickable ? "cursor-pointer hover:border-gh-accent/50" : ""}`}
       onClick={isClickable ? handleSelect : undefined}
-      onKeyDown={
-        isClickable
-          ? (e) => {
-              if (e.key === "Enter") handleSelect();
-            }
-          : undefined
-      }
-      role={isClickable ? "button" : undefined}
-      tabIndex={isClickable ? 0 : undefined}
     >
       {/* Header */}
       <div className="flex items-center gap-2.5 mb-3">
@@ -67,7 +63,7 @@ export default function ContributionCard({
           {result.data && (
             <img
               src={result.data.avatarUrl}
-              alt=""
+              alt={`${username}'s avatar`}
               className={`w-8 h-8 rounded-full transition-opacity duration-150 ${avatarLoaded ? "opacity-100" : "opacity-0"}`}
               onLoad={() => setAvatarLoaded(true)}
             />
@@ -77,7 +73,11 @@ export default function ContributionCard({
           <span className="font-semibold text-[15px]">
             {username}
             {hasStreak && (
-              <span className="ml-1 text-[13px]" title={`${currentStreak}d streak`}>
+              <span
+                className="ml-1 text-[13px]"
+                role="img"
+                aria-label={`${currentStreak} day streak`}
+              >
                 🔥
               </span>
             )}
@@ -104,7 +104,8 @@ export default function ContributionCard({
               <span
                 key={b.id}
                 className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full bg-gh-badge text-[11px] text-gh-text-secondary border border-gh-border shrink-0"
-                title={b.tooltip}
+                role="img"
+                aria-label={b.tooltip}
               >
                 <BadgeIcon icon={b.icon} />
                 {b.label}
@@ -146,14 +147,18 @@ export default function ContributionCard({
           </div>
         </div>
       )}
-      {result.error && <div className="text-gh-danger text-[13px] py-3">{result.error}</div>}
+      {result.error && (
+        <div role="alert" className="text-gh-danger text-[13px] py-3">
+          {result.error}
+        </div>
+      )}
       {collection && (
         <>
           <Heatmap weeks={collection.contributionCalendar.weeks} />
           <StatsBar collection={collection} visibleStats={visibleStats} />
         </>
       )}
-    </div>
+    </Wrapper>
   );
 }
 

--- a/src/components/DatePresets.tsx
+++ b/src/components/DatePresets.tsx
@@ -30,6 +30,7 @@ export default function DatePresets({
               setToDate(p.to);
               onSelect?.(p.from, p.to);
             }}
+            aria-pressed={active}
             className={`px-2.5 py-1 rounded-full text-xs font-medium border cursor-pointer transition-colors ${
               active
                 ? "bg-gh-accent/20 border-gh-accent text-gh-accent"

--- a/src/components/DayOfWeekChart.tsx
+++ b/src/components/DayOfWeekChart.tsx
@@ -19,33 +19,42 @@ export default function DayOfWeekChart({ weeks }: DayOfWeekChartProps) {
 
   const max = Math.max(...totals, 1);
 
+  const description = DISPLAY_ORDER.map((i) => `${DAY_LABELS[i]}: ${totals[i]}`).join(", ");
+
   return (
-    <div className="flex items-end gap-1 justify-between mb-3 px-1">
-      {DISPLAY_ORDER.map((i) => (
-        <div key={DAY_LABELS[i]} className="flex flex-col items-center gap-1 flex-1">
-          <span className="text-[10px] text-gh-text-secondary font-medium">{totals[i]}</span>
-          <div
-            className="w-full rounded-sm bg-gh-badge overflow-hidden flex flex-col justify-end"
-            style={{ height: 32 }}
-          >
+    <figure className="m-0" role="img" aria-label={`Contributions by day of week. ${description}`}>
+      <div className="flex items-end gap-1 justify-between mb-3 px-1">
+        {DISPLAY_ORDER.map((i) => (
+          <div key={DAY_LABELS[i]} className="flex flex-col items-center gap-1 flex-1">
+            <span className="text-[10px] text-gh-text-secondary font-medium" aria-hidden="true">
+              {totals[i]}
+            </span>
             <div
-              className="w-full rounded-sm transition-all duration-300"
-              style={{
-                height: `${(totals[i] / max) * 100}%`,
-                background:
-                  totals[i] === max
-                    ? "var(--contrib-q4)"
-                    : totals[i] > max * 0.5
-                      ? "var(--contrib-q3)"
-                      : totals[i] > 0
-                        ? "var(--contrib-q2)"
-                        : "transparent",
-              }}
-            />
+              className="w-full rounded-sm bg-gh-badge overflow-hidden flex flex-col justify-end"
+              style={{ height: 32 }}
+              aria-hidden="true"
+            >
+              <div
+                className="w-full rounded-sm transition-all duration-300"
+                style={{
+                  height: `${(totals[i] / max) * 100}%`,
+                  background:
+                    totals[i] === max
+                      ? "var(--contrib-q4)"
+                      : totals[i] > max * 0.5
+                        ? "var(--contrib-q3)"
+                        : totals[i] > 0
+                          ? "var(--contrib-q2)"
+                          : "transparent",
+                }}
+              />
+            </div>
+            <span className="text-[9px] text-gh-text-secondary" aria-hidden="true">
+              {DAY_LABELS[i]}
+            </span>
           </div>
-          <span className="text-[9px] text-gh-text-secondary">{DAY_LABELS[i]}</span>
-        </div>
-      ))}
-    </div>
+        ))}
+      </div>
+    </figure>
   );
 }

--- a/src/components/ExportButton.tsx
+++ b/src/components/ExportButton.tsx
@@ -12,7 +12,7 @@ export default function ExportButton({ elementSelector }: ExportButtonProps) {
       type="button"
       onClick={handleOnExport}
       className={`p-2 rounded-lg bg-gh-badge text-gh-text-secondary transition-colors border-none shrink-0 ${"hover:text-gh-text-primary cursor-pointer"}`}
-      title="Export as PNG"
+      aria-label="Export as PNG"
     >
       <svg
         width={18}
@@ -23,8 +23,7 @@ export default function ExportButton({ elementSelector }: ExportButtonProps) {
         strokeWidth={2}
         strokeLinecap="round"
         strokeLinejoin="round"
-        role="img"
-        aria-label="Export as PNG"
+        aria-hidden="true"
       >
         <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
         <polyline points="7 10 12 15 17 10" />

--- a/src/components/Heatmap.tsx
+++ b/src/components/Heatmap.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useRef, useState } from "react";
+import { useCallback, useId, useMemo, useRef, useState } from "react";
 import type { ContributionLevel, ContributionWeek } from "../lib/types";
 
 const CELL_SIZE = 13;
@@ -42,9 +42,19 @@ interface HeatmapProps {
 export default function Heatmap({ weeks }: HeatmapProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const [tooltip, setTooltip] = useState<TooltipData | null>(null);
+  const descId = useId();
 
   const width = LABEL_WIDTH + weeks.length * (CELL_SIZE + GAP);
   const height = 7 * (CELL_SIZE + GAP) + 20;
+
+  const totalContributions = useMemo(
+    () =>
+      weeks.reduce(
+        (sum, w) => sum + w.contributionDays.reduce((s, d) => s + d.contributionCount, 0),
+        0,
+      ),
+    [weeks],
+  );
 
   const monthLabels = useMemo(() => {
     const labels: { month: string; x: number; key: string }[] = [];
@@ -127,6 +137,11 @@ export default function Heatmap({ weeks }: HeatmapProps) {
 
   return (
     <div ref={containerRef} className="relative mb-3.5 bg-gh-badge rounded-lg p-3">
+      <div id={descId} className="sr-only">
+        {totalContributions} total contributions across {weeks.length} weeks. Colors range from no
+        contributions (empty) to highest activity (bright green). Hover or tap a cell to see
+        details.
+      </div>
       <div className="overflow-x-auto">
         <svg
           width={width}
@@ -135,6 +150,7 @@ export default function Heatmap({ weeks }: HeatmapProps) {
           xmlns="http://www.w3.org/2000/svg"
           role="img"
           aria-label="Contribution heatmap"
+          aria-describedby={descId}
           onMouseMove={handleMouseMove}
           onMouseLeave={handleMouseLeave}
           onClick={handleClick}
@@ -184,6 +200,9 @@ export default function Heatmap({ weeks }: HeatmapProps) {
 
       {tooltip && (
         <div
+          role="tooltip"
+          aria-live="polite"
+          aria-atomic="true"
           className="absolute z-50 pointer-events-none px-3 py-2 rounded-lg text-xs leading-relaxed whitespace-nowrap bg-gh-badge text-gh-text-primary border border-gh-border shadow-lg -translate-x-1/2 -translate-y-full"
           style={{ left: tooltip.x, top: tooltip.y }}
         >

--- a/src/components/SettingsDrawer.tsx
+++ b/src/components/SettingsDrawer.tsx
@@ -1,8 +1,16 @@
-import { useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { fetchOrgMembers } from "../lib/github";
 import { ALL_STATS } from "../lib/stats";
 import DatePresets from "./DatePresets";
 import UserChip from "./UserChip";
+
+function getFocusableElements(container: HTMLElement): HTMLElement[] {
+  return Array.from(
+    container.querySelectorAll<HTMLElement>(
+      'a[href], button:not([disabled]), textarea:not([disabled]), input:not([disabled]), select:not([disabled]), [tabindex]:not([tabindex="-1"])',
+    ),
+  );
+}
 
 const inputClass =
   "px-3 py-2 rounded-lg border border-gh-border bg-gh-card text-gh-text-primary text-sm outline-none focus:border-gh-accent";
@@ -59,6 +67,8 @@ export default function SettingsDrawer({
   const [userInput, setUserInput] = useState("");
   const [patVisible, setPatVisible] = useState(false);
   const [importingOrg, setImportingOrg] = useState(false);
+  const drawerRef = useRef<HTMLElement>(null);
+  const triggerRef = useRef<Element | null>(null);
 
   function addUser() {
     const u = userInput.trim().toLowerCase();
@@ -90,13 +100,56 @@ export default function SettingsDrawer({
     }
   }
 
+  // Focus the close button when the drawer opens, restore focus when it closes
+  useEffect(() => {
+    if (open) {
+      triggerRef.current = document.activeElement;
+      const focusable = drawerRef.current ? getFocusableElements(drawerRef.current) : [];
+      focusable[0]?.focus();
+    } else if (triggerRef.current instanceof HTMLElement) {
+      triggerRef.current.focus();
+      triggerRef.current = null;
+    }
+  }, [open]);
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === "Escape") {
+        e.stopPropagation();
+        onClose();
+        return;
+      }
+
+      if (e.key === "Tab" && drawerRef.current) {
+        const focusable = getFocusableElements(drawerRef.current);
+        if (focusable.length === 0) return;
+
+        const first = focusable[0];
+        const last = focusable[focusable.length - 1];
+
+        if (e.shiftKey) {
+          if (document.activeElement === first) {
+            e.preventDefault();
+            last.focus();
+          }
+        } else {
+          if (document.activeElement === last) {
+            e.preventDefault();
+            first.focus();
+          }
+        }
+      }
+    },
+    [onClose],
+  );
+
   return (
     <>
       {/* Backdrop */}
       {open && (
         <button
           type="button"
-          className="fixed inset-0 bg-black/50 z-20 transition-opacity w-full h-full cursor-default border-none"
+          className="fixed inset-0 bg-black/50 z-20 transition-opacity w-full h-full cursor-pointer border-none"
           tabIndex={-1}
           onClick={onClose}
           aria-label="Close settings"
@@ -104,7 +157,11 @@ export default function SettingsDrawer({
       )}
 
       {/* Drawer — full screen on mobile, 340px sidebar on sm+ */}
-      <div
+      <aside
+        ref={drawerRef}
+        inert={!open}
+        aria-label="Settings"
+        onKeyDown={open ? handleKeyDown : undefined}
         className={`fixed top-0 right-0 h-full w-full sm:w-[340px] bg-gh-bg border-l border-gh-border z-30 transform transition-transform duration-200 ${
           open ? "translate-x-0" : "translate-x-full"
         }`}
@@ -114,6 +171,7 @@ export default function SettingsDrawer({
           <button
             type="button"
             onClick={onClose}
+            aria-label="Close settings"
             className="bg-transparent border-none text-gh-text-secondary hover:text-gh-text-primary cursor-pointer text-xl leading-none p-1"
           >
             &times;
@@ -123,24 +181,32 @@ export default function SettingsDrawer({
         <div className="p-5 flex flex-col gap-5 overflow-y-auto h-[calc(100%-57px)]">
           {/* PAT section */}
           <div className="flex flex-col gap-2">
-            <span className={sectionLabel}>Personal Access Token</span>
+            <label htmlFor="pat-input" className={sectionLabel}>
+              Personal Access Token
+            </label>
             <div className="relative flex-1 min-w-[200px]">
               <input
+                id="pat-input"
                 type={patVisible ? "text" : "password"}
                 value={pat}
                 onChange={(e) => setPat(e.target.value)}
                 placeholder="ghp_..."
+                aria-describedby="pat-help"
                 className={`${inputClass} w-full pr-[50px]`}
               />
               <button
                 type="button"
                 onClick={() => setPatVisible(!patVisible)}
+                aria-label={
+                  patVisible ? "Hide personal access token" : "Show personal access token"
+                }
+                aria-pressed={patVisible}
                 className="absolute right-2 top-1/2 -translate-y-1/2 bg-transparent border-none text-gh-text-secondary cursor-pointer text-xs"
               >
                 {patVisible ? "Hide" : "Show"}
               </button>
             </div>
-            <p className="text-[11px] text-gh-text-secondary">
+            <p id="pat-help" className="text-[11px] text-gh-text-secondary">
               Requires{" "}
               <code className="bg-gh-badge px-1 py-0.5 rounded text-[11px]">read:user</code> and{" "}
               <code className="bg-gh-badge px-1 py-0.5 rounded text-[11px]">read:org</code> scopes.
@@ -150,8 +216,11 @@ export default function SettingsDrawer({
 
           {/* Org section */}
           <div className="flex flex-col gap-2">
-            <span className={sectionLabel}>Organization</span>
+            <label htmlFor="org-input" className={sectionLabel}>
+              Organization
+            </label>
             <input
+              id="org-input"
               value={org}
               onChange={(e) => setOrg(e.target.value)}
               placeholder="Optional — filter by org"
@@ -160,8 +229,8 @@ export default function SettingsDrawer({
           </div>
 
           {/* Date range section */}
-          <div className="flex flex-col gap-2">
-            <span className={sectionLabel}>Date Range</span>
+          <fieldset className="flex flex-col gap-2 border-none p-0 m-0">
+            <legend className={sectionLabel}>Date Range</legend>
             <DatePresets
               fromDate={fromDate}
               toDate={toDate}
@@ -169,27 +238,42 @@ export default function SettingsDrawer({
               setToDate={setToDate}
             />
             <div className="flex gap-2 items-center">
+              <label htmlFor="from-date" className="sr-only">
+                From date
+              </label>
               <input
+                id="from-date"
                 type="date"
                 value={fromDate}
                 onChange={(e) => setFromDate(e.target.value)}
+                aria-label="From date"
                 className={`${inputClass} flex-1`}
               />
-              <span className="text-gh-text-secondary text-xs">to</span>
+              <span className="text-gh-text-secondary text-xs" aria-hidden="true">
+                to
+              </span>
+              <label htmlFor="to-date" className="sr-only">
+                To date
+              </label>
               <input
+                id="to-date"
                 type="date"
                 value={toDate}
                 onChange={(e) => setToDate(e.target.value)}
+                aria-label="To date"
                 className={`${inputClass} flex-1`}
               />
             </div>
-          </div>
+          </fieldset>
 
           {/* Users section */}
           <div className="flex flex-col gap-2">
-            <span className={sectionLabel}>Users</span>
+            <label htmlFor="user-input" className={sectionLabel}>
+              Users
+            </label>
             <div className="flex gap-2">
               <input
+                id="user-input"
                 value={userInput}
                 onChange={(e) => setUserInput(e.target.value)}
                 onKeyDown={(e) => {
@@ -251,6 +335,7 @@ export default function SettingsDrawer({
                         setVisibleStats([...visibleStats, stat.id]);
                       }
                     }}
+                    aria-pressed={active}
                     className={`px-3 py-1 rounded-full text-xs font-medium border cursor-pointer transition-colors ${
                       active
                         ? "bg-gh-accent/20 border-gh-accent text-gh-accent"
@@ -288,7 +373,7 @@ export default function SettingsDrawer({
             </div>
           </div>
         </div>
-      </div>
+      </aside>
     </>
   );
 }

--- a/src/components/StatsBar.tsx
+++ b/src/components/StatsBar.tsx
@@ -12,21 +12,21 @@ export default function StatsBar({ collection, visibleStats }: StatsBarProps) {
   if (stats.length === 0) return null;
 
   return (
-    <div className="flex gap-2 justify-center">
+    <dl className="flex gap-2 justify-center m-0" aria-label="Contribution statistics">
       {stats.map((s) => (
         <div
           key={s.id}
           className="flex flex-col items-center px-2 sm:px-3.5 py-2 rounded-lg bg-gh-badge flex-1 min-w-0"
         >
-          <span className="text-xl font-bold">
+          <dd className="text-xl font-bold m-0">
             {s.getValue(collection)}
             {s.id === "streak" && (
               <span className="text-[11px] font-normal text-gh-text-secondary">d</span>
             )}
-          </span>
-          <span className="text-[11px] text-gh-text-secondary mt-0.5">{s.label}</span>
+          </dd>
+          <dt className="text-[11px] text-gh-text-secondary mt-0.5">{s.label}</dt>
         </div>
       ))}
-    </div>
+    </dl>
   );
 }

--- a/src/components/Toast.tsx
+++ b/src/components/Toast.tsx
@@ -27,7 +27,11 @@ interface ToastContainerProps {
 
 export default function ToastContainer({ toasts, onDismiss }: ToastContainerProps) {
   return (
-    <div className="fixed bottom-5 right-5 z-50 flex flex-col gap-2 max-w-sm">
+    <div
+      role="status"
+      aria-live="polite"
+      className="fixed bottom-5 right-5 z-50 flex flex-col gap-2 max-w-sm"
+    >
       {toasts.map((t) => (
         <ToastItem key={t.id} toast={t} onDismiss={() => onDismiss(t.id)} />
       ))}
@@ -50,6 +54,7 @@ function ToastItem({ toast, onDismiss }: { toast: ToastMessage; onDismiss: () =>
       <button
         type="button"
         onClick={onDismiss}
+        aria-label="Dismiss notification"
         className="bg-transparent border-none text-current opacity-60 hover:opacity-100 cursor-pointer text-base leading-none p-0"
       >
         &times;

--- a/src/components/Toolbar.tsx
+++ b/src/components/Toolbar.tsx
@@ -25,7 +25,10 @@ export default function Toolbar({
 }: ToolbarProps) {
   const { theme, cycleTheme } = useTheme();
   return (
-    <div className="sticky top-0 z-10 bg-gh-card border-b border-gh-border px-4 sm:px-6 py-3 -mx-4 sm:-mx-6 -mt-4 sm:-mt-6 mb-6 flex items-center gap-3">
+    <nav
+      aria-label="Toolbar"
+      className="sticky top-0 z-10 bg-gh-card border-b border-gh-border px-4 sm:px-6 py-3 -mx-4 sm:-mx-6 -mt-4 sm:-mt-6 mb-6 flex items-center gap-3"
+    >
       <h1 className="text-base sm:text-lg font-bold mr-auto truncate">GitHub Contributions</h1>
 
       {/* Date presets — desktop only */}
@@ -43,11 +46,13 @@ export default function Toolbar({
         type="button"
         onClick={() => onFetch()}
         disabled={isFetching}
+        aria-busy={isFetching}
         className={`px-4 py-2 rounded-lg border-none cursor-pointer font-semibold text-sm transition-opacity bg-gh-accent text-white shrink-0 ${
           isFetching ? "opacity-40 cursor-not-allowed" : "hover:opacity-85"
         }`}
       >
         {isFetching ? "Fetching..." : "Fetch"}
+        <kbd className="sr-only">R</kbd>
       </button>
 
       <ExportButton elementSelector="#dashboard" />
@@ -57,7 +62,7 @@ export default function Toolbar({
         type="button"
         onClick={cycleTheme}
         className="p-2 rounded-lg bg-gh-badge text-gh-text-secondary hover:text-gh-text-primary transition-colors cursor-pointer border-none shrink-0"
-        title={`Theme: ${theme}`}
+        aria-label={`Change theme (currently ${theme})`}
       >
         <ThemeIcon theme={theme} />
       </button>
@@ -67,7 +72,11 @@ export default function Toolbar({
         type="button"
         onClick={onOpenSettings}
         className="relative p-2 rounded-lg bg-gh-badge text-gh-text-secondary hover:text-gh-text-primary transition-colors cursor-pointer border-none shrink-0"
-        title="Settings"
+        aria-label={
+          userCount > 0
+            ? `Settings (${userCount} user${userCount === 1 ? "" : "s"} configured), press S`
+            : "Settings, press S"
+        }
       >
         <svg
           width="18"
@@ -78,8 +87,7 @@ export default function Toolbar({
           strokeWidth="2"
           strokeLinecap="round"
           strokeLinejoin="round"
-          role="img"
-          aria-label="Settings"
+          aria-hidden="true"
         >
           <path d="M12.22 2h-.44a2 2 0 0 0-2 2v.18a2 2 0 0 1-1 1.73l-.43.25a2 2 0 0 1-2 0l-.15-.08a2 2 0 0 0-2.73.73l-.22.38a2 2 0 0 0 .73 2.73l.15.1a2 2 0 0 1 1 1.72v.51a2 2 0 0 1-1 1.74l-.15.09a2 2 0 0 0-.73 2.73l.22.38a2 2 0 0 0 2.73.73l.15-.08a2 2 0 0 1 2 0l.43.25a2 2 0 0 1 1 1.73V20a2 2 0 0 0 2 2h.44a2 2 0 0 0 2-2v-.18a2 2 0 0 1 1-1.73l.43-.25a2 2 0 0 1 2 0l.15.08a2 2 0 0 0 2.73-.73l.22-.39a2 2 0 0 0-.73-2.73l-.15-.08a2 2 0 0 1-1-1.74v-.5a2 2 0 0 1 1-1.74l.15-.09a2 2 0 0 0 .73-2.73l-.22-.38a2 2 0 0 0-2.73-.73l-.15.08a2 2 0 0 1-2 0l-.43-.25a2 2 0 0 1-1-1.73V4a2 2 0 0 0-2-2z" />
           <circle cx="12" cy="12" r="3" />
@@ -91,7 +99,7 @@ export default function Toolbar({
           </span>
         )}
       </button>
-    </div>
+    </nav>
   );
 }
 
@@ -109,7 +117,7 @@ const svgProps = {
 function ThemeIcon({ theme }: { theme: "light" | "dark" | "system" }) {
   if (theme === "light") {
     return (
-      <svg {...svgProps} role="img" aria-label="Light mode">
+      <svg {...svgProps} aria-hidden="true">
         <circle cx="12" cy="12" r="4" />
         <path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M6.34 17.66l-1.41 1.41M19.07 4.93l-1.41 1.41" />
       </svg>
@@ -117,13 +125,13 @@ function ThemeIcon({ theme }: { theme: "light" | "dark" | "system" }) {
   }
   if (theme === "dark") {
     return (
-      <svg {...svgProps} role="img" aria-label="Dark mode">
+      <svg {...svgProps} aria-hidden="true">
         <path d="M12 3a6 6 0 0 0 9 9 9 9 0 1 1-9-9Z" />
       </svg>
     );
   }
   return (
-    <svg {...svgProps} role="img" aria-label="System theme">
+    <svg {...svgProps} aria-hidden="true">
       <rect x="2" y="3" width="20" height="14" rx="2" />
       <path d="M8 21h8M12 17v4" />
     </svg>

--- a/src/components/UserChip.tsx
+++ b/src/components/UserChip.tsx
@@ -10,6 +10,7 @@ export default function UserChip({ username, onRemove }: UserChipProps) {
       <button
         type="button"
         onClick={onRemove}
+        aria-label={`Remove ${username}`}
         className="bg-transparent border-none text-gh-text-secondary cursor-pointer text-base leading-none p-0 hover:text-gh-danger"
       >
         &times;

--- a/src/components/UserDetailModal.tsx
+++ b/src/components/UserDetailModal.tsx
@@ -247,7 +247,7 @@ export default function UserDetailModal({
             {/* Insights grid */}
             <div>
               <h3 className="text-sm font-medium text-gh-text-secondary mb-2">Insights</h3>
-              <div className="grid grid-cols-2 sm:grid-cols-4 gap-2">
+              <dl className="grid grid-cols-2 sm:grid-cols-4 gap-2 m-0">
                 <InsightCard label="Current Streak" value={`${insights.currentStreak}d`} />
                 <InsightCard label="Longest Streak" value={`${insights.longestStreak}d`} />
                 <InsightCard label="Daily Average" value={`${insights.dailyAverage}`} />
@@ -278,7 +278,7 @@ export default function UserDetailModal({
                     }
                   />
                 )}
-              </div>
+              </dl>
             </div>
 
             {/* Top repositories */}
@@ -346,9 +346,9 @@ export default function UserDetailModal({
 function InsightCard({ label, value, sub }: { label: string; value: string; sub?: string }) {
   return (
     <div className="flex flex-col items-center px-2 py-2.5 rounded-lg bg-gh-badge">
-      <span className="text-lg font-bold">{value}</span>
+      <dd className="text-lg font-bold m-0">{value}</dd>
       {sub && <span className="text-[10px] text-gh-text-secondary">{sub}</span>}
-      <span className="text-[11px] text-gh-text-secondary mt-0.5">{label}</span>
+      <dt className="text-[11px] text-gh-text-secondary mt-0.5">{label}</dt>
     </div>
   );
 }

--- a/src/index.css
+++ b/src/index.css
@@ -44,6 +44,18 @@
   filter: invert(0.7);
 }
 
+a {
+  text-decoration-line: underline;
+  text-decoration-color: var(--gh-accent);
+  text-underline-offset: 0.125em;
+  text-decoration-thickness: 1px;
+  transition: text-decoration-color 0.15s ease;
+}
+
+a:hover {
+  text-decoration-color: currentColor;
+}
+
 @keyframes slide-in {
   from {
     opacity: 0;
@@ -57,4 +69,17 @@
 
 .animate-slide-in {
   animation: slide-in 0.2s ease-out;
+}
+
+:focus-visible {
+  outline: 2px solid var(--gh-accent);
+  outline-offset: 2px;
+}
+
+button:focus-visible,
+a:focus-visible,
+input:focus-visible,
+[role="button"]:focus-visible {
+  outline: 2px solid var(--gh-accent);
+  outline-offset: 2px;
 }


### PR DESCRIPTION
## Summary

Comprehensive accessibility audit and fixes across the entire UI to improve keyboard navigation, screen reader support, and WCAG 2.1 AA compliance.

### Semantic HTML
- Replace root `<div>` with `<main>`, toolbar `<div>` with `<nav>`, drawer `<div>` with `<aside>`
- Use `<dl>`/`<dt>`/`<dd>` for StatsBar and InsightCard data
- Use `<fieldset>`/`<legend>` for the date range group
- Use `<figure>` with `aria-label` for the day-of-week chart
- Render clickable ContributionCard as a `<button>` instead of a `<div>` with synthetic keyboard handlers

### Screen reader support
- Add `aria-label` to all icon-only buttons (theme, settings, export, close, remove user)
- Add `aria-describedby` + hidden description for the heatmap SVG (total contributions, color scale explanation)
- Add `aria-live="polite"` to heatmap tooltip and toast container for dynamic content announcements
- Add `role="alert"` on error messages, `role="status"` on empty state
- Add `aria-pressed` on all toggle buttons (date presets, visible stats, PAT show/hide)
- Add `aria-busy` on the fetch button during loading
- Label the emoji heart with `role="img"` + `aria-label`
- Remove redundant `title` attributes on badges (unreliable on touch)

### Keyboard navigation
- Add skip link ("Skip to content") as first focusable element
- Add focus trap in SettingsDrawer (Tab/Shift+Tab cycling, Escape to close)
- Restore focus to trigger element when drawer closes
- Add `inert` attribute to drawer when closed
- Add keyboard shortcut hints to screen reader labels (R for fetch, S for settings)

### Form accessibility
- Associate all inputs with `<label>` elements (PAT, org, user, date inputs)
- Add `aria-describedby` linking PAT input to its help text
- Add `sr-only` labels for date range inputs

### Visual accessibility
- Add global `:focus-visible` outline using accent color
- Add underline styles to all links for non-color link identification
- Fix backdrop `cursor-default` → `cursor-pointer` to indicate interactivity

## Test plan
- [ ] Tab through the entire page — verify visible focus ring on every interactive element
- [ ] Open and close the settings drawer with keyboard only (S to open, Escape to close, Tab cycles within)
- [ ] Verify skip link appears on first Tab press and jumps to dashboard
- [ ] Test with VoiceOver/NVDA: icon buttons announce labels, toasts are announced, heatmap tooltip is read on hover
- [ ] Verify all toggle buttons announce pressed/not pressed state
- [ ] Check light and dark themes both show adequate focus indicators
- [ ] Test on mobile: badges no longer rely on `title` tooltip
