### PR TITLE
Add unit tests for core business logic

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,5 +25,8 @@ jobs:
       - name: Type check
         run: bunx tsc --noEmit
 
+      - name: Test
+        run: bun run test
+
       - name: Build
         run: bun run build

--- a/bun.lock
+++ b/bun.lock
@@ -19,6 +19,7 @@
         "tailwindcss": "^3.4.17",
         "typescript": "^5.8.3",
         "vite": "^6.3.2",
+        "vitest": "^4.1.2",
       },
     },
   },
@@ -201,6 +202,8 @@
 
     "@rollup/rollup-win32-x64-msvc": ["@rollup/rollup-win32-x64-msvc@4.60.0", "", { "os": "win32", "cpu": "x64" }, "sha512-PrsWNQ8BuE00O3Xsx3ALh2Df8fAj9+cvvX9AIA6o4KpATR98c9mud4XtDWVvsEuyia5U4tVSTKygawyJkjm60w=="],
 
+    "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
+
     "@types/babel__core": ["@types/babel__core@7.20.5", "", { "dependencies": { "@babel/parser": "^7.20.7", "@babel/types": "^7.20.7", "@types/babel__generator": "*", "@types/babel__template": "*", "@types/babel__traverse": "*" } }, "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA=="],
 
     "@types/babel__generator": ["@types/babel__generator@7.27.0", "", { "dependencies": { "@babel/types": "^7.0.0" } }, "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg=="],
@@ -208,6 +211,10 @@
     "@types/babel__template": ["@types/babel__template@7.4.4", "", { "dependencies": { "@babel/parser": "^7.1.0", "@babel/types": "^7.0.0" } }, "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A=="],
 
     "@types/babel__traverse": ["@types/babel__traverse@7.28.0", "", { "dependencies": { "@babel/types": "^7.28.2" } }, "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q=="],
+
+    "@types/chai": ["@types/chai@5.2.3", "", { "dependencies": { "@types/deep-eql": "*", "assertion-error": "^2.0.1" } }, "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA=="],
+
+    "@types/deep-eql": ["@types/deep-eql@4.0.2", "", {}, "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw=="],
 
     "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
 
@@ -217,11 +224,27 @@
 
     "@vitejs/plugin-react": ["@vitejs/plugin-react@4.7.0", "", { "dependencies": { "@babel/core": "^7.28.0", "@babel/plugin-transform-react-jsx-self": "^7.27.1", "@babel/plugin-transform-react-jsx-source": "^7.27.1", "@rolldown/pluginutils": "1.0.0-beta.27", "@types/babel__core": "^7.20.5", "react-refresh": "^0.17.0" }, "peerDependencies": { "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0" } }, "sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA=="],
 
+    "@vitest/expect": ["@vitest/expect@4.1.2", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "@types/chai": "^5.2.2", "@vitest/spy": "4.1.2", "@vitest/utils": "4.1.2", "chai": "^6.2.2", "tinyrainbow": "^3.1.0" } }, "sha512-gbu+7B0YgUJ2nkdsRJrFFW6X7NTP44WlhiclHniUhxADQJH5Szt9mZ9hWnJPJ8YwOK5zUOSSlSvyzRf0u1DSBQ=="],
+
+    "@vitest/mocker": ["@vitest/mocker@4.1.2", "", { "dependencies": { "@vitest/spy": "4.1.2", "estree-walker": "^3.0.3", "magic-string": "^0.30.21" }, "peerDependencies": { "msw": "^2.4.9", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0" }, "optionalPeers": ["msw", "vite"] }, "sha512-Ize4iQtEALHDttPRCmN+FKqOl2vxTiNUhzobQFFt/BM1lRUTG7zRCLOykG/6Vo4E4hnUdfVLo5/eqKPukcWW7Q=="],
+
+    "@vitest/pretty-format": ["@vitest/pretty-format@4.1.2", "", { "dependencies": { "tinyrainbow": "^3.1.0" } }, "sha512-dwQga8aejqeuB+TvXCMzSQemvV9hNEtDDpgUKDzOmNQayl2OG241PSWeJwKRH3CiC+sESrmoFd49rfnq7T4RnA=="],
+
+    "@vitest/runner": ["@vitest/runner@4.1.2", "", { "dependencies": { "@vitest/utils": "4.1.2", "pathe": "^2.0.3" } }, "sha512-Gr+FQan34CdiYAwpGJmQG8PgkyFVmARK8/xSijia3eTFgVfpcpztWLuP6FttGNfPLJhaZVP/euvujeNYar36OQ=="],
+
+    "@vitest/snapshot": ["@vitest/snapshot@4.1.2", "", { "dependencies": { "@vitest/pretty-format": "4.1.2", "@vitest/utils": "4.1.2", "magic-string": "^0.30.21", "pathe": "^2.0.3" } }, "sha512-g7yfUmxYS4mNxk31qbOYsSt2F4m1E02LFqO53Xpzg3zKMhLAPZAjjfyl9e6z7HrW6LvUdTwAQR3HHfLjpko16A=="],
+
+    "@vitest/spy": ["@vitest/spy@4.1.2", "", {}, "sha512-DU4fBnbVCJGNBwVA6xSToNXrkZNSiw59H8tcuUspVMsBDBST4nfvsPsEHDHGtWRRnqBERBQu7TrTKskmjqTXKA=="],
+
+    "@vitest/utils": ["@vitest/utils@4.1.2", "", { "dependencies": { "@vitest/pretty-format": "4.1.2", "convert-source-map": "^2.0.0", "tinyrainbow": "^3.1.0" } }, "sha512-xw2/TiX82lQHA06cgbqRKFb5lCAy3axQ4H4SoUFhUsg+wztiet+co86IAMDtF6Vm1hc7J6j09oh/rgDn+JdKIQ=="],
+
     "any-promise": ["any-promise@1.3.0", "", {}, "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A=="],
 
     "anymatch": ["anymatch@3.1.3", "", { "dependencies": { "normalize-path": "^3.0.0", "picomatch": "^2.0.4" } }, "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw=="],
 
     "arg": ["arg@5.0.2", "", {}, "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg=="],
+
+    "assertion-error": ["assertion-error@2.0.1", "", {}, "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA=="],
 
     "autoprefixer": ["autoprefixer@10.4.27", "", { "dependencies": { "browserslist": "^4.28.1", "caniuse-lite": "^1.0.30001774", "fraction.js": "^5.3.4", "picocolors": "^1.1.1", "postcss-value-parser": "^4.2.0" }, "peerDependencies": { "postcss": "^8.1.0" }, "bin": { "autoprefixer": "bin/autoprefixer" } }, "sha512-NP9APE+tO+LuJGn7/9+cohklunJsXWiaWEfV3si4Gi/XHDwVNgkwr1J3RQYFIvPy76GmJ9/bW8vyoU1LcxwKHA=="],
 
@@ -236,6 +259,8 @@
     "camelcase-css": ["camelcase-css@2.0.1", "", {}, "sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA=="],
 
     "caniuse-lite": ["caniuse-lite@1.0.30001781", "", {}, "sha512-RdwNCyMsNBftLjW6w01z8bKEvT6e/5tpPVEgtn22TiLGlstHOVecsX2KHFkD5e/vRnIE4EGzpuIODb3mtswtkw=="],
+
+    "chai": ["chai@6.2.2", "", {}, "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg=="],
 
     "chokidar": ["chokidar@3.6.0", "", { "dependencies": { "anymatch": "~3.1.2", "braces": "~3.0.2", "glob-parent": "~5.1.2", "is-binary-path": "~2.1.0", "is-glob": "~4.0.1", "normalize-path": "~3.0.0", "readdirp": "~3.6.0" }, "optionalDependencies": { "fsevents": "~2.3.2" } }, "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw=="],
 
@@ -255,9 +280,15 @@
 
     "electron-to-chromium": ["electron-to-chromium@1.5.323", "", {}, "sha512-oQm+FxbazvN2WICCbvJgj3IYPKV8awip57+W5VP+Aatk4kFU4pDYCPHZOX22Z27zpw8uttBehEqgK+VTJAYrVw=="],
 
+    "es-module-lexer": ["es-module-lexer@2.0.0", "", {}, "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw=="],
+
     "esbuild": ["esbuild@0.25.12", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.25.12", "@esbuild/android-arm": "0.25.12", "@esbuild/android-arm64": "0.25.12", "@esbuild/android-x64": "0.25.12", "@esbuild/darwin-arm64": "0.25.12", "@esbuild/darwin-x64": "0.25.12", "@esbuild/freebsd-arm64": "0.25.12", "@esbuild/freebsd-x64": "0.25.12", "@esbuild/linux-arm": "0.25.12", "@esbuild/linux-arm64": "0.25.12", "@esbuild/linux-ia32": "0.25.12", "@esbuild/linux-loong64": "0.25.12", "@esbuild/linux-mips64el": "0.25.12", "@esbuild/linux-ppc64": "0.25.12", "@esbuild/linux-riscv64": "0.25.12", "@esbuild/linux-s390x": "0.25.12", "@esbuild/linux-x64": "0.25.12", "@esbuild/netbsd-arm64": "0.25.12", "@esbuild/netbsd-x64": "0.25.12", "@esbuild/openbsd-arm64": "0.25.12", "@esbuild/openbsd-x64": "0.25.12", "@esbuild/openharmony-arm64": "0.25.12", "@esbuild/sunos-x64": "0.25.12", "@esbuild/win32-arm64": "0.25.12", "@esbuild/win32-ia32": "0.25.12", "@esbuild/win32-x64": "0.25.12" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg=="],
 
     "escalade": ["escalade@3.2.0", "", {}, "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA=="],
+
+    "estree-walker": ["estree-walker@3.0.3", "", { "dependencies": { "@types/estree": "^1.0.0" } }, "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g=="],
+
+    "expect-type": ["expect-type@1.3.0", "", {}, "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA=="],
 
     "fast-glob": ["fast-glob@3.3.3", "", { "dependencies": { "@nodelib/fs.stat": "^2.0.2", "@nodelib/fs.walk": "^1.2.3", "glob-parent": "^5.1.2", "merge2": "^1.3.0", "micromatch": "^4.0.8" } }, "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg=="],
 
@@ -305,6 +336,8 @@
 
     "lru-cache": ["lru-cache@5.1.1", "", { "dependencies": { "yallist": "^3.0.2" } }, "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w=="],
 
+    "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
+
     "merge2": ["merge2@1.4.1", "", {}, "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg=="],
 
     "micromatch": ["micromatch@4.0.8", "", { "dependencies": { "braces": "^3.0.3", "picomatch": "^2.3.1" } }, "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA=="],
@@ -323,7 +356,11 @@
 
     "object-hash": ["object-hash@3.0.0", "", {}, "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw=="],
 
+    "obug": ["obug@2.1.1", "", {}, "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ=="],
+
     "path-parse": ["path-parse@1.0.7", "", {}, "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="],
+
+    "pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
 
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
 
@@ -371,7 +408,13 @@
 
     "semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
+    "siginfo": ["siginfo@2.0.0", "", {}, "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g=="],
+
     "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
+
+    "stackback": ["stackback@0.0.2", "", {}, "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw=="],
+
+    "std-env": ["std-env@4.0.0", "", {}, "sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ=="],
 
     "sucrase": ["sucrase@3.35.1", "", { "dependencies": { "@jridgewell/gen-mapping": "^0.3.2", "commander": "^4.0.0", "lines-and-columns": "^1.1.6", "mz": "^2.7.0", "pirates": "^4.0.1", "tinyglobby": "^0.2.11", "ts-interface-checker": "^0.1.9" }, "bin": { "sucrase": "bin/sucrase", "sucrase-node": "bin/sucrase-node" } }, "sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw=="],
 
@@ -383,7 +426,13 @@
 
     "thenify-all": ["thenify-all@1.6.0", "", { "dependencies": { "thenify": ">= 3.1.0 < 4" } }, "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA=="],
 
+    "tinybench": ["tinybench@2.9.0", "", {}, "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg=="],
+
+    "tinyexec": ["tinyexec@1.0.4", "", {}, "sha512-u9r3uZC0bdpGOXtlxUIdwf9pkmvhqJdrVCH9fapQtgy/OeTTMZ1nqH7agtvEfmGui6e1XxjcdrlxvxJvc3sMqw=="],
+
     "tinyglobby": ["tinyglobby@0.2.15", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.3" } }, "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ=="],
+
+    "tinyrainbow": ["tinyrainbow@3.1.0", "", {}, "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw=="],
 
     "to-regex-range": ["to-regex-range@5.0.1", "", { "dependencies": { "is-number": "^7.0.0" } }, "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ=="],
 
@@ -396,6 +445,10 @@
     "util-deprecate": ["util-deprecate@1.0.2", "", {}, "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="],
 
     "vite": ["vite@6.4.1", "", { "dependencies": { "esbuild": "^0.25.0", "fdir": "^6.4.4", "picomatch": "^4.0.2", "postcss": "^8.5.3", "rollup": "^4.34.9", "tinyglobby": "^0.2.13" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0", "jiti": ">=1.21.0", "less": "*", "lightningcss": "^1.21.0", "sass": "*", "sass-embedded": "*", "stylus": "*", "sugarss": "*", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g=="],
+
+    "vitest": ["vitest@4.1.2", "", { "dependencies": { "@vitest/expect": "4.1.2", "@vitest/mocker": "4.1.2", "@vitest/pretty-format": "4.1.2", "@vitest/runner": "4.1.2", "@vitest/snapshot": "4.1.2", "@vitest/spy": "4.1.2", "@vitest/utils": "4.1.2", "es-module-lexer": "^2.0.0", "expect-type": "^1.3.0", "magic-string": "^0.30.21", "obug": "^2.1.1", "pathe": "^2.0.3", "picomatch": "^4.0.3", "std-env": "^4.0.0-rc.1", "tinybench": "^2.9.0", "tinyexec": "^1.0.2", "tinyglobby": "^0.2.15", "tinyrainbow": "^3.1.0", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@opentelemetry/api": "^1.9.0", "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0", "@vitest/browser-playwright": "4.1.2", "@vitest/browser-preview": "4.1.2", "@vitest/browser-webdriverio": "4.1.2", "@vitest/ui": "4.1.2", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@opentelemetry/api", "@types/node", "@vitest/browser-playwright", "@vitest/browser-preview", "@vitest/browser-webdriverio", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "vitest.mjs" } }, "sha512-xjR1dMTVHlFLh98JE3i/f/WePqJsah4A0FK9cc8Ehp9Udk0AZk6ccpIZhh1qJ/yxVWRZ+Q54ocnD8TXmkhspGg=="],
+
+    "why-is-node-running": ["why-is-node-running@2.3.0", "", { "dependencies": { "siginfo": "^2.0.0", "stackback": "0.0.2" }, "bin": { "why-is-node-running": "cli.js" } }, "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w=="],
 
     "yallist": ["yallist@3.1.1", "", {}, "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="],
 

--- a/package.json
+++ b/package.json
@@ -9,7 +9,9 @@
     "preview": "vite preview",
     "lint": "biome check .",
     "lint:fix": "biome check --write .",
-    "format": "biome format --write ."
+    "format": "biome format --write .",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "dependencies": {
     "html-to-image": "^1.11.13",
@@ -25,6 +27,7 @@
     "postcss": "^8.5.3",
     "tailwindcss": "^3.4.17",
     "typescript": "^5.8.3",
-    "vite": "^6.3.2"
+    "vite": "^6.3.2",
+    "vitest": "^4.1.2"
   }
 }

--- a/src/lib/__tests__/badges.test.ts
+++ b/src/lib/__tests__/badges.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+import { computeBadges } from "../badges";
+import type { UserResult } from "../types";
+import { collection, result, week } from "./fixtures";
+
+describe("computeBadges", () => {
+  it("returns empty when fewer than 2 users have data", () => {
+    const results: Record<string, UserResult> = {
+      alice: result(collection([week([["2026-03-01", 10]])])),
+    };
+    expect(computeBadges(results)).toEqual({});
+  });
+
+  it("returns empty for zero-value results", () => {
+    const results: Record<string, UserResult> = {
+      alice: result(collection([week([["2026-03-01", 0]])])),
+      bob: result(collection([week([["2026-03-01", 0]])])),
+    };
+    expect(computeBadges(results)).toEqual({});
+  });
+
+  it("awards badge to clear winner", () => {
+    const results: Record<string, UserResult> = {
+      alice: result(
+        collection([week([["2026-03-01", 10]])], {
+          totalCommitContributions: 50,
+        }),
+      ),
+      bob: result(
+        collection([week([["2026-03-01", 5]])], {
+          totalCommitContributions: 20,
+        }),
+      ),
+    };
+    const badges = computeBadges(results);
+    // Alice should win "Activity Ace" (10 vs 5 total contributions)
+    // and "Commit Captain" (50 vs 20 commits)
+    expect(badges.alice).toBeDefined();
+    expect(badges.alice.some((b) => b.id === "most-active")).toBe(true);
+    expect(badges.alice.some((b) => b.id === "top-committer")).toBe(true);
+  });
+
+  it("does not award badge on tie", () => {
+    const results: Record<string, UserResult> = {
+      alice: result(
+        collection([week([["2026-03-01", 10]])], {
+          totalCommitContributions: 30,
+        }),
+      ),
+      bob: result(
+        collection([week([["2026-03-01", 10]])], {
+          totalCommitContributions: 30,
+        }),
+      ),
+    };
+    const badges = computeBadges(results);
+    // Tied on everything — no badges awarded
+    const allBadges = Object.values(badges).flat();
+    expect(allBadges.find((b) => b.id === "top-committer")).toBeUndefined();
+    expect(allBadges.find((b) => b.id === "most-active")).toBeUndefined();
+  });
+
+  it("skips users with only loading/error state", () => {
+    const results: Record<string, UserResult> = {
+      alice: result(
+        collection([week([["2026-03-01", 10]])], {
+          totalCommitContributions: 50,
+        }),
+      ),
+      bob: { loading: true },
+      charlie: { error: "not found" },
+    };
+    // Only 1 user with data → no badges
+    expect(computeBadges(results)).toEqual({});
+  });
+});

--- a/src/lib/__tests__/datePresets.test.ts
+++ b/src/lib/__tests__/datePresets.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+import type { DatePreset } from "../datePresets";
+import { getDatePresets } from "../datePresets";
+
+function findPreset(id: string): DatePreset {
+  const preset = getDatePresets().find((p) => p.id === id);
+  if (!preset) throw new Error(`Preset "${id}" not found`);
+  return preset;
+}
+
+describe("getDatePresets", () => {
+  it("returns 6 presets", () => {
+    const presets = getDatePresets();
+    expect(presets).toHaveLength(6);
+  });
+
+  it("all presets have required fields", () => {
+    for (const p of getDatePresets()) {
+      expect(p.id).toBeTruthy();
+      expect(p.label).toBeTruthy();
+      expect(p.from).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+      expect(p.to).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+    }
+  });
+
+  it("from date is before to date for all presets", () => {
+    for (const p of getDatePresets()) {
+      expect(new Date(p.from).getTime()).toBeLessThanOrEqual(new Date(p.to).getTime());
+    }
+  });
+
+  it("7d preset is exactly 7 days back", () => {
+    const p = findPreset("7d");
+    const diffDays = Math.round(
+      (new Date(p.to).getTime() - new Date(p.from).getTime()) / 86_400_000,
+    );
+    expect(diffDays).toBe(7);
+  });
+
+  it("30d preset is exactly 30 days back", () => {
+    const p = findPreset("30d");
+    const diffDays = Math.round(
+      (new Date(p.to).getTime() - new Date(p.from).getTime()) / 86_400_000,
+    );
+    expect(diffDays).toBe(30);
+  });
+
+  it("90d preset is exactly 90 days back", () => {
+    const p = findPreset("90d");
+    const diffDays = Math.round(
+      (new Date(p.to).getTime() - new Date(p.from).getTime()) / 86_400_000,
+    );
+    expect(diffDays).toBe(90);
+  });
+
+  it("YTD starts on Jan 1 of current year", () => {
+    const p = findPreset("ytd");
+    const year = new Date().getFullYear();
+    expect(p.from).toBe(`${year}-01-01`);
+  });
+
+  it("This year covers full current year", () => {
+    const p = findPreset("year");
+    const year = new Date().getFullYear();
+    expect(p.from).toBe(`${year}-01-01`);
+    expect(p.to).toBe(`${year}-12-31`);
+  });
+});

--- a/src/lib/__tests__/fixtures.ts
+++ b/src/lib/__tests__/fixtures.ts
@@ -1,0 +1,65 @@
+import type {
+  ContributionDay,
+  ContributionsCollection,
+  ContributionWeek,
+  GitHubUser,
+  UserResult,
+} from "../types";
+
+/** Create a contribution day with sensible defaults. */
+export function day(date: string, contributionCount: number, weekday = 0): ContributionDay {
+  let level: ContributionDay["contributionLevel"] = "NONE";
+  if (contributionCount > 0) level = "FIRST_QUARTILE";
+  if (contributionCount >= 5) level = "SECOND_QUARTILE";
+  if (contributionCount >= 10) level = "THIRD_QUARTILE";
+  if (contributionCount >= 20) level = "FOURTH_QUARTILE";
+  return { date, contributionCount, contributionLevel: level, weekday };
+}
+
+/** Create a week from an array of [date, count] pairs. */
+export function week(days: [string, number, number?][]): ContributionWeek {
+  return {
+    contributionDays: days.map(([date, count, wd]) => day(date, count, wd ?? 0)),
+  };
+}
+
+/** Create a minimal ContributionsCollection. */
+export function collection(
+  weeks: ContributionWeek[],
+  overrides: Partial<ContributionsCollection> = {},
+): ContributionsCollection {
+  const total = weeks.reduce(
+    (sum, w) => sum + w.contributionDays.reduce((s, d) => s + d.contributionCount, 0),
+    0,
+  );
+  return {
+    totalCommitContributions: 0,
+    totalPullRequestContributions: 0,
+    totalPullRequestReviewContributions: 0,
+    totalIssueContributions: 0,
+    totalRepositoryContributions: 0,
+    commitContributionsByRepository: [],
+    contributionCalendar: { totalContributions: total, weeks },
+    ...overrides,
+  };
+}
+
+/** Create a minimal GitHubUser with the given collection. */
+export function user(col: ContributionsCollection): GitHubUser {
+  return {
+    avatarUrl: "https://example.com/avatar.png",
+    bio: null,
+    company: null,
+    location: null,
+    websiteUrl: null,
+    createdAt: "2020-01-01T00:00:00Z",
+    followers: { totalCount: 0 },
+    following: { totalCount: 0 },
+    contributionsCollection: col,
+  };
+}
+
+/** Create a UserResult with data. */
+export function result(col: ContributionsCollection): UserResult {
+  return { data: user(col) };
+}

--- a/src/lib/__tests__/insights.test.ts
+++ b/src/lib/__tests__/insights.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "vitest";
+import { computeInsights } from "../insights";
+import { week } from "./fixtures";
+
+describe("computeInsights", () => {
+  it("computes peak day correctly", () => {
+    const weeks = [
+      week([
+        ["2026-03-01", 1, 0],
+        ["2026-03-02", 10, 1],
+        ["2026-03-03", 3, 2],
+      ]),
+    ];
+    const insights = computeInsights(weeks);
+    expect(insights.peakDay).toEqual({ date: "2026-03-02", count: 10 });
+  });
+
+  it("computes active days and total days", () => {
+    const weeks = [
+      week([
+        ["2026-03-01", 1, 0],
+        ["2026-03-02", 0, 1],
+        ["2026-03-03", 3, 2],
+        ["2026-03-04", 0, 3],
+      ]),
+    ];
+    const insights = computeInsights(weeks);
+    expect(insights.activeDays).toBe(2);
+    expect(insights.totalDays).toBe(4);
+  });
+
+  it("computes daily average", () => {
+    const weeks = [
+      week([
+        ["2026-03-01", 4, 0],
+        ["2026-03-02", 6, 1],
+      ]),
+    ];
+    const insights = computeInsights(weeks);
+    expect(insights.dailyAverage).toBe(5); // (4+6)/2
+  });
+
+  it("uses computeStreak for streak values (skips future dates)", () => {
+    const today = new Date().toISOString().split("T")[0];
+    const tomorrow = new Date(Date.now() + 86_400_000).toISOString().split("T")[0];
+    const dayAfter = new Date(Date.now() + 2 * 86_400_000).toISOString().split("T")[0];
+
+    const weeks = [
+      week([
+        [today, 3],
+        [tomorrow, 0],
+        [dayAfter, 0],
+      ]),
+    ];
+    const insights = computeInsights(weeks);
+    // Should use computeStreak which skips future dates
+    expect(insights.currentStreak).toBe(1);
+  });
+
+  it("computes busiest day of week", () => {
+    // weekday 1 = Monday in GitHub's schema
+    const weeks = [
+      week([
+        ["2026-03-02", 10, 1], // Monday
+        ["2026-03-03", 2, 2], // Tuesday
+        ["2026-03-09", 8, 1], // Monday
+        ["2026-03-10", 4, 2], // Tuesday
+      ]),
+    ];
+    const insights = computeInsights(weeks);
+    expect(insights.busiestDayOfWeek.day).toBe("Mon"); // avg 9 vs avg 3
+  });
+
+  it("handles empty weeks", () => {
+    const insights = computeInsights([]);
+    expect(insights.totalDays).toBe(0);
+    expect(insights.activeDays).toBe(0);
+    expect(insights.dailyAverage).toBe(0);
+    expect(insights.currentStreak).toBe(0);
+    expect(insights.longestStreak).toBe(0);
+  });
+});

--- a/src/lib/__tests__/streaks.test.ts
+++ b/src/lib/__tests__/streaks.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vitest";
+import { computeStreak } from "../streaks";
+import { week } from "./fixtures";
+
+describe("computeStreak", () => {
+  it("returns zero for empty weeks", () => {
+    const result = computeStreak([]);
+    expect(result).toEqual({ longest: 0, current: 0 });
+  });
+
+  it("computes longest streak across days", () => {
+    const weeks = [
+      week([
+        ["2026-03-01", 1],
+        ["2026-03-02", 5],
+        ["2026-03-03", 3],
+        ["2026-03-04", 0],
+        ["2026-03-05", 2],
+        ["2026-03-06", 1],
+      ]),
+    ];
+    const result = computeStreak(weeks);
+    expect(result.longest).toBe(3); // Mar 1-3
+  });
+
+  it("computes current streak scanning backward from today", () => {
+    const today = new Date().toISOString().split("T")[0];
+    const yesterday = new Date(Date.now() - 86_400_000).toISOString().split("T")[0];
+    const twoDaysAgo = new Date(Date.now() - 2 * 86_400_000).toISOString().split("T")[0];
+
+    const weeks = [
+      week([
+        [twoDaysAgo, 3],
+        [yesterday, 5],
+        [today, 2],
+      ]),
+    ];
+    const result = computeStreak(weeks);
+    expect(result.current).toBe(3);
+  });
+
+  it("current streak stops at a zero-contribution day", () => {
+    const today = new Date().toISOString().split("T")[0];
+    const yesterday = new Date(Date.now() - 86_400_000).toISOString().split("T")[0];
+    const twoDaysAgo = new Date(Date.now() - 2 * 86_400_000).toISOString().split("T")[0];
+
+    const weeks = [
+      week([
+        [twoDaysAgo, 0],
+        [yesterday, 5],
+        [today, 2],
+      ]),
+    ];
+    const result = computeStreak(weeks);
+    expect(result.current).toBe(2);
+  });
+
+  it("skips future dates when computing current streak", () => {
+    const today = new Date().toISOString().split("T")[0];
+    const tomorrow = new Date(Date.now() + 86_400_000).toISOString().split("T")[0];
+    const dayAfter = new Date(Date.now() + 2 * 86_400_000).toISOString().split("T")[0];
+
+    const weeks = [
+      week([
+        [today, 3],
+        [tomorrow, 0], // future zero — should be skipped
+        [dayAfter, 0], // future zero — should be skipped
+      ]),
+    ];
+    const result = computeStreak(weeks);
+    expect(result.current).toBe(1); // only today counts
+  });
+
+  it("current streak is zero when today has no contributions", () => {
+    const today = new Date().toISOString().split("T")[0];
+    const yesterday = new Date(Date.now() - 86_400_000).toISOString().split("T")[0];
+
+    const weeks = [
+      week([
+        [yesterday, 5],
+        [today, 0],
+      ]),
+    ];
+    const result = computeStreak(weeks);
+    expect(result.current).toBe(0);
+  });
+});

--- a/src/lib/__tests__/velocity.test.ts
+++ b/src/lib/__tests__/velocity.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import { computeVelocity } from "../velocity";
+import { collection, week } from "./fixtures";
+
+describe("computeVelocity", () => {
+  it("returns null when previousPeriodTotal is undefined", () => {
+    const col = collection([week([["2026-03-01", 10]])]);
+    expect(computeVelocity(col, undefined)).toBeNull();
+  });
+
+  it("computes positive velocity", () => {
+    const col = collection([week([["2026-03-01", 10]])]); // total = 10
+    const result = computeVelocity(col, 5);
+    expect(result).not.toBeNull();
+    expect(result?.percentage).toBe(100); // (10-5)/5 * 100
+    expect(result?.currentTotal).toBe(10);
+    expect(result?.previousTotal).toBe(5);
+  });
+
+  it("computes negative velocity", () => {
+    const col = collection([week([["2026-03-01", 3]])]); // total = 3
+    const result = computeVelocity(col, 10);
+    expect(result?.percentage).toBe(-70); // (3-10)/10 * 100
+  });
+
+  it("returns 0% when both periods are zero", () => {
+    const col = collection([week([["2026-03-01", 0]])]); // total = 0
+    const result = computeVelocity(col, 0);
+    expect(result?.percentage).toBe(0);
+  });
+
+  it("returns 100% when previous was zero but current is positive", () => {
+    const col = collection([week([["2026-03-01", 5]])]); // total = 5
+    const result = computeVelocity(col, 0);
+    expect(result?.percentage).toBe(100);
+  });
+
+  it("returns 0% when current equals previous", () => {
+    const col = collection([week([["2026-03-01", 8]])]); // total = 8
+    const result = computeVelocity(col, 8);
+    expect(result?.percentage).toBe(0);
+  });
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,4 +4,7 @@ import { defineConfig } from "vite";
 export default defineConfig({
   base: "/",
   plugins: [react()],
+  test: {
+    globals: true,
+  },
 });


### PR DESCRIPTION
## Summary
- Set up Vitest as the test framework (integrates with existing Vite config)
- Added 31 unit tests covering the pure utility functions most likely to regress:
  - `computeStreak` — empty input, longest/current streak, future date skipping
  - `computeInsights` — peak day, active days, daily average, streak delegation, busiest day
  - `computeVelocity` — null return, positive/negative velocity, zero/equal cases
  - `computeBadges` — single user, zero values, clear winner, ties, loading/error states
  - `getDatePresets` — preset count, field validity, exact day-back math (7d/30d/90d), YTD, full year
- Added shared test fixtures (`day`, `week`, `collection`, `user`, `result` builders)
- Added `test` and `test:watch` scripts to package.json
- Added test step to CI pipeline (runs between typecheck and build)

## Test plan
- [x] `bun run test` — 31 tests pass
- [x] `bun run build` — typecheck + production build pass
- [x] `bun run lint` — Biome check passes