### PR TITLE
Batch fetch results for smoother card transitions

### DIFF
--- a/src/lib/useContributions.ts
+++ b/src/lib/useContributions.ts
@@ -107,32 +107,33 @@ export function useContributions({
         }
       }
 
-      // Fetch all users in parallel with progressive updates
+      // Fetch all users in parallel, then apply results in a single batch
+      // so cards and badges transition from skeleton to data simultaneously
       let errorCount = 0;
-      await Promise.all(
+      const settled = await Promise.allSettled(
         users.map(async (user) => {
-          try {
-            const [data, previousPeriodTotal] = await Promise.all([
-              fetchUserContributions(pat, user, { orgId, from, to }, signal),
-              fetchPreviousPeriodTotal(pat, user, { orgId, from: prevFrom, to: prevTo }, signal),
-            ]);
-            if (signal.aborted) return;
-            setResults((r) => ({
-              ...r,
-              [user]: { data, previousPeriodTotal, periodDays },
-            }));
-          } catch (e) {
-            if (signal.aborted) return;
-            errorCount++;
-            setResults((prev) => ({
-              ...prev,
-              [user]: { error: (e as Error).message },
-            }));
-          }
+          const [data, previousPeriodTotal] = await Promise.all([
+            fetchUserContributions(pat, user, { orgId, from, to }, signal),
+            fetchPreviousPeriodTotal(pat, user, { orgId, from: prevFrom, to: prevTo }, signal),
+          ]);
+          return { user, data, previousPeriodTotal };
         }),
       );
 
       if (signal.aborted) return;
+
+      const batch: Record<string, UserResult> = {};
+      for (let i = 0; i < users.length; i++) {
+        const result = settled[i];
+        if (result.status === "fulfilled") {
+          const { data, previousPeriodTotal } = result.value;
+          batch[users[i]] = { data, previousPeriodTotal, periodDays };
+        } else {
+          errorCount++;
+          batch[users[i]] = { error: result.reason?.message ?? String(result.reason) };
+        }
+      }
+      setResults((prev) => ({ ...prev, ...batch }));
       setIsFetching(false);
 
       // Defer toast so the card transitions settle before triggering another render


### PR DESCRIPTION
## Summary
- Replace progressive per-user `setResults` calls with `Promise.allSettled` + a single batched state update
- Cards now stay in skeleton state until **all** fetches complete, then transition together with badges already computed
- Eliminates badge flickering caused by `computeBadges` re-running on every individual result update

## Test plan
- [ ] Fetch with 2+ users — all cards should show skeleton, then appear together with badges
- [ ] Trigger a fetch error (e.g. typo in username) — errored card shows error, others show data, all in one transition
- [ ] Change date range mid-fetch — stale results should not be applied (abort guard)
- [ ] Add a single user via settings — still updates progressively (uses `fetchUser`, not `fetchAll`)