### PR TITLE
Persist selected users to localStorage

### DIFF
--- a/src/lib/useSettings.ts
+++ b/src/lib/useSettings.ts
@@ -37,6 +37,17 @@ function decodeState(encoded: string): UrlState | null {
   }
 }
 
+const STORAGE_KEY = "ghcd-settings";
+
+function readStateFromStorage(): UrlState | null {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    return raw ? decodeState(raw) : null;
+  } catch {
+    return null;
+  }
+}
+
 function readStateFromUrl(): UrlState | null {
   const params = new URLSearchParams(window.location.search);
   const s = params.get("state");
@@ -62,7 +73,7 @@ export interface UseSettingsReturn {
 }
 
 export function useSettings(): UseSettingsReturn {
-  const [initial] = useState(() => readStateFromUrl());
+  const [initial] = useState(() => readStateFromUrl() ?? readStateFromStorage());
 
   const [rawPat, setRawPat] = useState(() => localStorage.getItem("ghcd-pat") ?? "");
   const [rawOrg, setRawOrg] = useState(() => initial?.org ?? "");
@@ -101,6 +112,12 @@ export function useSettings(): UseSettingsReturn {
       url.searchParams.delete("state");
     }
     window.history.replaceState(null, "", url.toString());
+
+    if (Object.keys(state).length > 0) {
+      localStorage.setItem(STORAGE_KEY, encodeState(state));
+    } else {
+      localStorage.removeItem(STORAGE_KEY);
+    }
   }, [users, org, fromDate, toDate, visibleStats]);
 
   return {


### PR DESCRIPTION
## Summary
- Persist user settings (users, org, date range, visible stats) to `localStorage` so they are restored when revisiting the app without a URL state parameter
- URL state still takes priority — localStorage is only used as a fallback
- Settings are cleared from storage when all values are empty

## QA instructions
- Load the app, add some users, then close and reopen the tab (without a `?state=` param) — settings should be restored
- Verify that a `?state=` URL param still takes priority over stored settings
- Clear all users/settings and confirm `localStorage` entry is removed